### PR TITLE
Update jasyncq to 1.1.0

### DIFF
--- a/apiserver/requirements.txt
+++ b/apiserver/requirements.txt
@@ -8,4 +8,4 @@ gunicorn==20.0.4
 python-json-logger==0.1.11
 deserialize==1.8.0
 motor==2.0.0
-jasyncq==0.1.2
+jasyncq==1.1.0

--- a/apiserver/resource/notifications.py
+++ b/apiserver/resource/notifications.py
@@ -3,6 +3,7 @@ import datetime
 from typing import List, Optional
 
 import deserialize
+from jasyncq.dispatcher.model.task import TaskIn
 from jasyncq.dispatcher.tasks import TasksDispatcher
 
 from apiserver.decorator.request import request_error_handler
@@ -186,9 +187,14 @@ class NotificationsHttpResource(AbstractResource):
         }]
         try:
             await self.notification_task_queue.apply_tasks(
-                tasks=tasks,
-                queue_name='NOTIFICATION_JOB_QUEUE',
-                scheduled_at=int(notification.scheduled_at.timestamp())
+                tasks=[
+                    TaskIn(
+                        task=task,
+                        queue_name='NOTIFICATION_JOB_QUEUE',
+                        scheduled_at=int(notification.scheduled_at.timestamp()),
+                    )
+                    for task in tasks
+                ],
             )
         except Exception as e:  # rollback if queue pushing failed
             logger.warning(f'rollback because of queue pushing failed {e}')

--- a/worker/messaging/replica.py
+++ b/worker/messaging/replica.py
@@ -5,7 +5,7 @@ from typing import Dict, List
 import aiomysql
 import deserialize
 from jasyncq.dispatcher.tasks import TasksDispatcher
-from jasyncq.model.task import Task
+from jasyncq.dispatcher.model.task import TaskOut
 from jasyncq.repository.tasks import TaskRepository
 
 from common.logger.logger import get_logger
@@ -118,7 +118,7 @@ class Replica:
                 limit=self.TASK_FETCH_SIZE,
             )
 
-            tasks: List[Task] = [*pending_tasks, *scheduled_tasks]
+            tasks: List[TaskOut] = [*pending_tasks, *scheduled_tasks]
             if not tasks:
                 # NOTE(pjongy): Relax wasting
                 await asyncio.sleep(1)

--- a/worker/messaging/requirements.txt
+++ b/worker/messaging/requirements.txt
@@ -5,6 +5,6 @@ python-json-logger==0.1.11
 google-auth==1.20.1
 requests==2.25.0
 python-dateutil==2.8.1
-jasyncq==0.1.2
+jasyncq==1.1.0
 PyPika==0.37.6
 aiomysql==0.0.20

--- a/worker/messaging/task/send_push_message.py
+++ b/worker/messaging/task/send_push_message.py
@@ -1,6 +1,7 @@
 import dataclasses
 
 import deserialize
+from jasyncq.dispatcher.model.task import TaskIn
 from jasyncq.dispatcher.tasks import TasksDispatcher
 
 from common.logger.logger import get_logger
@@ -60,15 +61,17 @@ class SendPushMessageTask(AbstractTask):
         logger.info(f'sent: {sent}, failed: {failed}')
         await self.notification_task_queue.apply_tasks(
             tasks=[
-                dataclasses.asdict(deserialize.deserialize(NotificationJob, {
-                    'task': NotificationTask.UPDATE_RESULT,
-                    'kwargs': {
-                        'device_platform': task_args.device_platform,
-                        'notification_uuid': task_args.notification_id,
-                        'sent': sent,
-                        'failed': failed,
-                    }
-                }))
+                TaskIn(
+                    task=dataclasses.asdict(deserialize.deserialize(NotificationJob, {
+                        'task': NotificationTask.UPDATE_RESULT,
+                        'kwargs': {
+                            'device_platform': task_args.device_platform,
+                            'notification_uuid': task_args.notification_id,
+                            'sent': sent,
+                            'failed': failed,
+                        }
+                    })),
+                    queue_name='NOTIFICATION_JOB_QUEUE',
+                )
             ],
-            queue_name='NOTIFICATION_JOB_QUEUE'
         )

--- a/worker/notification/replica.py
+++ b/worker/notification/replica.py
@@ -5,7 +5,7 @@ from typing import Dict, List
 import aiomysql
 import deserialize
 from jasyncq.dispatcher.tasks import TasksDispatcher
-from jasyncq.model.task import Task
+from jasyncq.dispatcher.model.task import TaskOut
 from jasyncq.repository.tasks import TaskRepository
 
 from common.logger.logger import get_logger
@@ -93,7 +93,7 @@ class Replica:
                 limit=self.TASK_FETCH_SIZE,
             )
 
-            tasks: List[Task] = [*pending_tasks, *scheduled_tasks]
+            tasks: List[TaskOut] = [*pending_tasks, *scheduled_tasks]
             if not tasks:
                 # NOTE(pjongy): Relax wasting
                 await asyncio.sleep(1)

--- a/worker/notification/requirements.txt
+++ b/worker/notification/requirements.txt
@@ -2,7 +2,7 @@ aiomysql==0.0.20
 deserialize==1.8.0
 gunicorn==20.0.4
 httpx==0.14.0
-jasyncq==0.1.2
+jasyncq==1.1.0
 python-dateutil==2.8.1
 python-json-logger==0.1.11
 PyPika==0.37.6

--- a/worker/notification/task/launch_notification.py
+++ b/worker/notification/task/launch_notification.py
@@ -2,6 +2,7 @@ import asyncio
 import dataclasses
 
 import deserialize
+from jasyncq.dispatcher.model.task import TaskIn
 from jasyncq.dispatcher.tasks import TasksDispatcher
 
 from common.logger.logger import get_logger
@@ -78,7 +79,12 @@ class LaunchNotificationTask(AbstractTask):
                     notification_id=notification.id,
                 ),
                 self.messaging_task_queue.apply_tasks(
-                    tasks=tasks,
-                    queue_name='MESSAGING_QUEUE'
+                    tasks=[
+                        TaskIn(
+                            task=task,
+                            queue_name='MESSAGING_QUEUE',
+                        )
+                        for task in tasks
+                    ],
                 )
             )


### PR DESCRIPTION
- jasyncq uses pydantic as model base
- 1.1.0 supports urgent task and task dependencies